### PR TITLE
Fix undefined property access on useArrayDocument hook

### DIFF
--- a/src/lib/hooks/useArrayDocument.ts
+++ b/src/lib/hooks/useArrayDocument.ts
@@ -60,9 +60,9 @@ export function useArrayDocument<T>(
           cachedDocsId.map((id) => getDoc(doc(collection, id)))
         );
 
-        const docs = docsSnapshot.map((doc) =>
-          doc.data({ serverTimestamps: 'estimate' })
-        );
+        const docs = docsSnapshot
+          .filter((doc) => doc.exists())
+          .map((doc) => doc.data({ serverTimestamps: 'estimate' }));
 
         if (!docs.length) {
           setData(null);


### PR DESCRIPTION
Fixes #23.

Filter documents that don't exist when the cloud function has a delay in updating a document or if the project doesn't use the cloud function.